### PR TITLE
Support browser targets in package exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "browser": "browser",
   "exports": {
     ".": {
+      "browser": {
+        "require": "./browser.js",
+        "import": "./browser.mjs"
+      },
       "require": "./node.js",
       "import": "./node.mjs"
     }


### PR DESCRIPTION
Since Webpack 5 respects `"exports"` specifications in `package.json`s, it now ignores the separate `"browser"` field and loads `node.{,m}js` for browser targets. This leads to the `ws` package throwing an error every time a `WebSocket` is constructed instead of using the native `WebSocket` implementation of the browser. In the case of `@d-fischer/connection` and its consumers `ircv3` and `twitch-chat-client`, this is leading to silent failures of `WebSocketConnection`s with infinite retry loops.

This PR extends the `"exports"` field to cover browser targets as well as non-browser (Node.js) ones, returning the correct behavior to Webpack 5.